### PR TITLE
Fix importlib error

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -24,9 +24,7 @@ suite("python_evaluator Tests", () => {
         default_filter_vars: [],
         default_filter_types: ["<class 'module'>", "<class 'function'>"]
     }
-    const pythonStartupTime = 3500
-    // python 3.7 has much faster startup time
-    // when we drop support for 3.6 we can decrease this
+    const pythonStartupTime = 3000
 
     suiteSetup(function (done) {
         this.timeout(pythonStartupTime + 500)
@@ -66,6 +64,15 @@ suite("python_evaluator Tests", () => {
             done()
         }
         input.evalCode = "x=1"
+        pyEvaluator.execCode(input)
+    })
+
+    test("can import importlib", function (done) {
+        pyEvaluator.onResult = (result) => {
+            assert.strictEqual(result.userErrorMsg, undefined)
+            done()
+        }
+        input.evalCode = "import importlib.resources as rsrc"
         pyEvaluator.execCode(input)
     })
 

--- a/python/arepl_python_evaluator.py
+++ b/python/arepl_python_evaluator.py
@@ -25,6 +25,7 @@ modules_to_keep.update(
         "arepl_jsonpickle.ext.pandas",
         "arepl_jsonpickle.ext.numpy",
         "typing",  # for some reason i can't clear this or jsonpickle breaks
+        "typing.io", # if this gets cleared then py 3.8 & 3.10 breaks
     )
 )
 # when arepl is ran via unit test/debugging some extra libraries might be in modules_to_keep


### PR DESCRIPTION
Resolves https://github.com/Almenon/AREPL-vscode/issues/416

I clear the all the modules before the start of the run, because AREPL imports certain modules that I don't want to immediately be available to the user.  I want the user to have to import them, just like they would in a normal python file. In general I want a AREPL run to replicate the execution of a normal python file, ideally down to the last detail. 

However, I was clearing `typing.io`, which can't be reimported for some reason. To fix this I simply added `typing.io` in to the list of modules to keep.

For some reason I don't get the error when using pytest, hence why I wrote the testcase in the typescript file.