### PR TITLE
fix: switch to node 20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -32,9 +29,9 @@ jobs:
       - name: Test with pytest
         run: pytest
 
-      - name: Use Node.js 16
-        uses: actions/setup-node@v2.1.2
+      - name: Setup Node
+        uses: actions/setup-node@v4.1.0
         with:
-          node-version: "16"
+          node-version: "20"
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
need to do this for upgrading semantic release. Hopefully upgrading my various packages will fix the error I'm getting in https://github.com/Almenon/AREPL-vscode/pull/456


https://github.com/Almenon/AREPL-vscode/actions/runs/11850487428/job/33025447543

```
> tsc -p ./

Error: src/PreviewManager.ts(2,41): error TS230[7](https://github.com/Almenon/AREPL-vscode/actions/runs/11850487428/job/33025447543#step:5:8): Cannot find module 'arepl-backend' or its corresponding type declarations.
```

It's a very odd error because I get this on Ubuntu but not mac or my local windows.